### PR TITLE
fix: allow polyfilling in workers plus other bits

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,6 +1,7 @@
 import { lookup } from "https://deno.land/x/media_types@v2.7.1/mod.ts";
+import { iter } from "https://deno.land/std@0.97.0/io/util.ts";
 
-const originalfetch = window.fetch;
+const originalfetch = globalThis.fetch;
 
 async function fetch(
   input: string | Request | URL,
@@ -33,7 +34,7 @@ async function fetch(
     }
     const body = new ReadableStream<Uint8Array>({
       start: async (controller) => {
-        for await (const chunk of Deno.iter(file)) {
+        for await (const chunk of iter(file)) {
           controller.enqueue(chunk);
         }
         file.close();
@@ -63,7 +64,6 @@ async function fetch(
       },
       configurable: true,
       enumerable: true,
-      writable: true,
     });
     return response;
   }

--- a/polyfill.ts
+++ b/polyfill.ts
@@ -1,3 +1,3 @@
 import { fetch } from "./mod.ts";
 
-window.fetch = fetch;
+globalThis.fetch = fetch;


### PR DESCRIPTION
`globalThis` should be used instead of `window` so that the polyfill can be loaded in workers, which have `fetch` available to them.